### PR TITLE
easy replacement of month dropdown menus

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,23 +12,23 @@
 
 - ## :high_brightness: Open Source Event
 
-    ### 1- Google Summer of Code [link](https://summerofcode.withgoogle.com)
+    ### (JAN) 1- Google Summer of Code [link](https://summerofcode.withgoogle.com)
 	     Organisation form start
      >- ***Google Summer of Code*** is a global program focused on introducing students to open source software development. Students work on a 3-month programming project with an open-source organization during their break from university.
     
-    ### 2- JIIT Open-Source Developers Circle (JODC)
+    ### (JAN) 2- JIIT Open-Source Developers Circle (JODC)
 	    Student Application form open
     >- ***JIIT Month of Code*** is an online programme by the open-source club of Jaypee Institute of Information Technology, JIIT Noida-128, the JODC, focused on introducing students to open source software development and documentation writing.
 
-    ### 3- GirlScript Summer of Code [link](https://www.gssoc.tech)
+    ### (JAN) 3- GirlScript Summer of Code [link](https://www.gssoc.tech)
 	    Mentor Application Start
     >- **GirlScript Summer of Code** is the 3 months long Open Source program during summers conducted by GirlScript Foundation, started in 2018, with an aim to help beginners get started with Open Source Development while encouraging diversity.
     
-    ### 4- Outreachy [Link](https://www.outreachy.org)
+    ### (JAN) 4- Outreachy [Link](https://www.outreachy.org)
     
     >- ***Outreachy*** provides internships to work in open source and free software.  Outreachy internships are open to applicants around the world. Interns work remotely and are not required to move. Interns are paid a stipend of $5,500 USD for the three-month internship. Interns have a $500 USD travel stipend to attend conferences or events.
 
-	### 5- OpenCode IIITA [Link](https://opencodeiiita.github.io)
+	### (JAN) 5- OpenCode IIITA [Link](https://opencodeiiita.github.io)
     
     >- ***OpenCode*** is a month-long program starting in January for students to start there journey in the world of open source.  
 The Only requirement being an enthusiastic heart to learn.
@@ -39,20 +39,20 @@ The Only requirement being an enthusiastic heart to learn.
 
 - ## :high_brightness: Open Source Event
 
-    ### 1- STEP(Google) [link](https://careers.google.com/students/engineering-and-technical-internships/)
+    ### (FEB) 1- STEP(Google) [link](https://careers.google.com/students/engineering-and-technical-internships/)
 	    Deadline for applications
     >- ***STEP*** program is a developmental opportunity for ***first- and second-year undergraduate students*** with a passion for technology—especially students from historically underrepresented groups in the field.
     
-    ### 2- Google Summer of Code [link](https://summerofcode.withgoogle.com)
+    ### (FEB) 2- Google Summer of Code [link](https://summerofcode.withgoogle.com)
     
 	    List of accepted mentoring organizations published
     >-  ****Google Summer of Code**** is a global program focused on introducing students to open source software development. Students work on a 3-month programming project with an open-source organization during their break from university.
 
-	### 3- Open Mainframe Project Mentorship Program- Linux Foundation [link](https://www.openmainframeproject.org/projects/mentorship-program)
+	### (FEB) 3- Open Mainframe Project Mentorship Program- Linux Foundation [link](https://www.openmainframeproject.org/projects/mentorship-program)
 		Deadline for applications
 	>-  The ***Open Mainframe Project*** funds mentees to complete projects during the period between semesters in the months of May, June, July, August, and September. Upon successful completion of the mentorship, mentees are invited to present at an industry conference. The Open Mainframe Project funds travel and expenses for mentees.
 	
-	### 4- Red Hat Open Source Contest [link](https://research.redhat.com/red-hat-open-source-contest/)
+	### (FEB) 4- Red Hat Open Source Contest [link](https://research.redhat.com/red-hat-open-source-contest/)
 		Project list available
 	>-  ***Red Hat Open Source Contest*** is a competition for students during which we want to show students how easy it is to participate in open source projects. Students can also get feedback on their code and get it included in a real project. By participating in the Red Hat Open Source Contest students can win nice prizes.
 	>- Exceptional participants may receive offers for an internship at Red Hat. The overall contest winner receives an eshop coupon worth 10,000 CZK
@@ -63,31 +63,31 @@ The Only requirement being an enthusiastic heart to learn.
 
 - ## :high_brightness: Open Source Event
 
-	###  1- Codess [link](https://www.codess.net/about-codess/)
+	###  (MAR) 1- Codess [link](https://www.codess.net/about-codess/)
 		Phase 1 Student application
    >- ***Codess*** is a community for female coders initiated by Microsoft and was established to explore ways to promote gender diversity in the engineering field. Since its inception in 2013 in London, Codess has been inspiring women in engineering and helping them achieve their professional goals.
    >-  The best part: Approximately 30 participants were extended offers to intern at Microsoft
 	
-	###  2- Google Summer of Earth Engine [link](https://sites.google.com/view/summerofearthengine/home?authuser=0)
+	###  (MAR) 2- Google Summer of Earth Engine [link](https://sites.google.com/view/summerofearthengine/home?authuser=0)
 		Student application Start
    >- **Google Summer of Earth Engine** is a research program for Indian university students & researchers to get a chance to work with leading research organizations in the country working in **environment**, **conservation**, **water resources** and **agricultural** domains over **3 months** of summer on a project and get paid to do so!
    >- This program is based on the [Google Summer of Code](https://summerofcode.withgoogle.com/) model.
 
-	###  3- RAILS GIRLS SUMMER OF CODE [link](https://railsgirlssummerofcode.org)
+	###  (MAR) 3- RAILS GIRLS SUMMER OF CODE [link](https://railsgirlssummerofcode.org)
 		Student application stage
 	>- **RAILS GIRLS SUMMER OF CODE** is a global fellowship program for ***women and non-binary coders***. Students receive a three-month scholarship to work on existing Open Source projects and expand their skill set.
 
-	###  4- Linux Kernel Mentorship Programlink [Link](https://wiki.linuxfoundation.org/lkmp)
+	###  (MAR) 4- Linux Kernel Mentorship Programlink [Link](https://wiki.linuxfoundation.org/lkmp)
 		Summer Program
    >- The ***Linux Kernel Mentorship Program*** offers a structured remote learning opportunity to aspiring Linux Kernel developers. Experienced Linux Kernel developers and maintainers mentor volunteer mentees and help them become contributors to the Linux Kernel.
    >- The Linux Kernel Mentorship Program includes three 12-week, full-time volunteer mentee positions, and two 24-week part-time volunteer mentee positions each year. Please check the [Summer 2020 Linux Kernel Mentorship Program](https://wiki.linuxfoundation.org/lkmp/lkmp_schedule "https://wiki.linuxfoundation.org/lkmp/lkmp_schedule") and get started. **This is a remote opportunity and there is no need to relocate or move to participate.**
 
 	
-	###  5- Free Software Foundation [link](https://www.fsf.org/author/fsfweb)
+	###  (MAR) 5- Free Software Foundation [link](https://www.fsf.org/author/fsfweb)
 		Spring Student application
    >- This is an educational opportunity to work with the organization that sponsors the GNU Project, publishes the GNU General Public License (GPL), and fights for software freedom.
    
-   ###  6 - Linux Foundation Networking Mentorship - LFN Mentorship [link](https://wiki.lfnetworking.org/display/LN/LFN+Mentorship+Program)
+   ###  (MAR) 6 - Linux Foundation Networking Mentorship - LFN Mentorship [link](https://wiki.lfnetworking.org/display/LN/LFN+Mentorship+Program)
 		
 	>- The LF Networking (LFN) intern/mentorship program is aimed at creating a structured hands-on learning opportunity for new developers who may otherwise lack the opportunity to gain exposure to open source software development and entry to the LFN projects' technical communities.
 	>- Each mentee will apply and be matched with a mentor or mentors who are active developers and technologiests contributing to the industry's leading open source networking projects such as ONAP, OPNFV, OpenDaylight, FD.io. Each mentee will work remotely from his/her location of choice.
@@ -96,16 +96,16 @@ The Only requirement being an enthusiastic heart to learn.
 
 # <u> :walking: `April` :bulb:</u>
 - ## :high_brightness: Open Source Event
-	###  1-RARE Technologies Student Incubator Programme  [link](https://rare-technologies.com/incubator/#details)
+	###  (APR) 1-RARE Technologies Student Incubator Programme  [link](https://rare-technologies.com/incubator/#details)
 		Student application
    >- Our student Incubator offers a unique mix of academic mentorship, hand-on project work and technical training. It is a highly selective program where you will be mentored by an industry expert as you develop a pragmatic solution to a real-world problem using machine learning.
 
-	###  2-Igalia Web Engines Hackfest[link](https://www.igalia.com/2020/02/03/The-2020-Web-Engines-Hackfest-is-happening-in-May.html)  
+	###  (APR) 2-Igalia Web Engines Hackfest[link](https://www.igalia.com/2020/02/03/The-2020-Web-Engines-Hackfest-is-happening-in-May.html)  
 		Student application in process
 	>- ***Igalia*** has been hosting the Web Engines Hackfest every year since 2009. And every year the event has grown bigger, with an increasing number of participants and broader areas of interest.
 
 
-	###  3- BOSS - Bountiful Open Source Summer [link](https://lab.codingblocks.com/boss)
+	###  (APR) 3- BOSS - Bountiful Open Source Summer [link](https://lab.codingblocks.com/boss)
 		Student application in process
 	>- Each year we teach hundreds of students coding, programming and software development. Over the past five years (we started off in April 2014), we have helped more than 3000 students gain expertise in Android, Web, Data Science and more.
 	>- BOSS 2019 is open to any _**Indian Student**_. You could be a student enrolled in any school or a college or university.
@@ -115,24 +115,24 @@ The Only requirement being an enthusiastic heart to learn.
 # <u> :massage_man: `May` :full_moon_with_face:</u>
 - ## :high_brightness: Open Source Event
 
-	###  1- Season of Docs [link](https://developers.google.com/season-of-docs)
+	###  (MAY) 1- Season of Docs [link](https://developers.google.com/season-of-docs)
 		Organizations announced
    >- **Google Season of Docs** is a program giving technical writers an opportunity to contribute to open source projects, by paying them a three month stipend and facilitating connections between writers and projects. As a platform that’s all about supporting the open source community, we think this is fantastic, because a lot of open source projects really need documentation help.
 
-	###  2-ESA Summer of Code in Space[link](https://www.esa.int/Enabling_Support/Space_Engineering_Technology/SOCIS_The_ESA_Summer_of_Code_in_Space)
+	###  (MAY) 2-ESA Summer of Code in Space[link](https://www.esa.int/Enabling_Support/Space_Engineering_Technology/SOCIS_The_ESA_Summer_of_Code_in_Space)
 		Open Source Software Submission Deadline
    >- ***ESA Summer of Code in Space*** (SOCIS) is a program run by the European Space Agency that focuses on bringing student developers into open source software development for space applications. Students work with a mentoring organization (with potential support from ESA experts) on a 3 month programming project during their summer break.
    
-   ###  3- OSS World Challenge [link](https://www.oss.kr/en_oss_world_challenage)
+   ###  (MAY) 3- OSS World Challenge [link](https://www.oss.kr/en_oss_world_challenage)
 		Challenge opens every May			
    >- **Open Source Software World Challenge** is an annual competition hosted by the Ministry of Science, ICT and Future Planning of Korea.
    >- Open to anyone national interested in open source software.
    >- Bring together the gems of open source developers to cultivate developing-skills through cooperated projects which will eventually expand the open source minds/spirit and practices among community.
 
-	### 4- ACM MM Open Source Software Competition [link](http://sigmm.org/Resources/software/ossc)
+	### (MAY) 4- ACM MM Open Source Software Competition [link](http://sigmm.org/Resources/software/ossc)
 		Deadline for applications
 	>-  The Open Source Software Competition is an important part of the ***ACM Multimedia program***. The competition, now in its 17th edition, is intended to celebrate, encourage and promote the contribution of researchers, software developers and educators to advance the field by providing the community with implementations of codecs, middleware, frameworks, toolkits, libraries, multimedia players, applications, authoring tools, and other multimedia software.
-	### 5- MLH Fellowship [link](https://fellowship.mlh.io)
+	### (MAY) 5- MLH Fellowship [link](https://fellowship.mlh.io)
 		Application Starts
 	>-  The MLH Fellowship is an internship alternative for software engineers. Instead of working on a project for just one company, you'll contribute to Open Source projects that are used by companies around the world. You'll collaborate with a group of 10 students under the guidance of a professional mentor whose only job is to help you successfully contribute.
 <br>
@@ -140,7 +140,7 @@ The Only requirement being an enthusiastic heart to learn.
 # <u> :running: `June` :hourglass_flowing_sand: </u>
 - ## :high_brightness: Open Source Event
 
-	###  1- Linux Kernel Mentorship Programlink [Link](https://wiki.linuxfoundation.org/lkmp)
+	###  (JUN) 1- Linux Kernel Mentorship Programlink [Link](https://wiki.linuxfoundation.org/lkmp)
 		Fall Program
    >- The  [Linux Kernel Mentorship Program](https://drive.google.com/file/d/1_P70rjCfiLq6PkqxTbhF0_y0bcA-Ryj-/view?usp=sharing "https://drive.google.com/file/d/1_P70rjCfiLq6PkqxTbhF0_y0bcA-Ryj-/view?usp=sharing")  offers a structured remote learning opportunity to aspiring Linux Kernel developers. Experienced Linux Kernel developers and maintainers mentor volunteer mentees and help them become contributors to the Linux Kernel.
 
@@ -150,7 +150,7 @@ The Only requirement being an enthusiastic heart to learn.
 # <u> :horse_racing: `July` :computer: </u>
 - ## :high_brightness: Open Source Event
 
-	###  1- Alibaba Summer of Code [link](https://alibaba.github.io)
+	###  (JUL) 1- Alibaba Summer of Code [link](https://alibaba.github.io)
 		Work begin
    >- ***Alibaba Summer of Code*** is a global program focused on engaging students directly into open source software development. Under the guidance of the mentor in the Alibaba open source project, students experience the software development in the real world.
    >- On this exclusive developer journey, students will have the opportunity to: Participate in the top projects of the International Open Source Foundation, Get a fast pass of Alibaba Internship/recruitment.
@@ -160,7 +160,7 @@ The Only requirement being an enthusiastic heart to learn.
 # <u> :beers: `August` :mag:</u>
 - ## :1st_place_medal: Hackathon
 
-    ### 1- InOut Hackathon  [link](https://hackinout.co)  
+    ### (AUG) 1- InOut Hackathon  [link](https://hackinout.co)  
 	    Application period start
     >- ***InOut*** prides itself on being India’s biggest community hackathon.
 	>- Since its inception in 2015, InOut has been a platform where technology leaders and the brightest minds come together to collaborate on building tools that solve real problems. 
@@ -172,13 +172,13 @@ The Only requirement being an enthusiastic heart to learn.
 
 - ## :high_brightness: Open Source Event
 
-	### 1- CodeHeat Coding Contest of FOSSASIA  [link](https://codeheat.org)
+	### (SEP) 1- CodeHeat Coding Contest of FOSSASIA  [link](https://codeheat.org)
 
 	>- In the ***Heat of the Code*** is a coding contest for [FOSSASIA projects on GitHub](https://github.com/fossasia/).  
 	>The contest runs until February. Grand prize winners will be invited to present their work at the [FOSSASIA OpenTechSummit](https://2020.fossasia.org/) in Singapore in March and will get up to 600 SGD in travel funding to attend, plus a free speaker ticket.
 	> Other participants will have the chance to win Tshirts, Swag and vouchers to attend Open Tech events in the region and will get certificates of participation.
 
-	 ### 2- MDG Season of Code- IIT-R [link](http://mdg.iitr.ac.in/soc.html)
+	 ### (SEP) 2- MDG Season of Code- IIT-R [link](http://mdg.iitr.ac.in/soc.html)
 	    countdown start
    >- ***MDG*** is an active student group of IIT Roorkee directing its efforts towards creating useful mobile applications and promoting tech-based learning for the same.
    >- Perks - Direct Interview, Mentorship from MDG, T-Shirts and Goodies
@@ -189,22 +189,22 @@ The Only requirement being an enthusiastic heart to learn.
 
 - ## :high_brightness: Open Source Event        
     
-    ### 1- Hacktoberfest [link](https://hacktoberfest.digitalocean.com)
+    ### (OCT) 1- Hacktoberfest [link](https://hacktoberfest.digitalocean.com)
 	    countdown start
     >- ***Hacktoberfest*** is a month-long celebration of open source software run by DigitalOcean and DEV. Hacktoberfest is open to everyone in our global community. To participate, four pull requests must be submitted to public GitHub repositories. You can sign up anytime between October 1 and October 31.
     
-    ### 2- Pycon [link](https://in.pycon.org/2020/)
+    ### (OCT) 2- Pycon [link](https://in.pycon.org/2020/)
     >- ***Pycon*** is the premier conference in India on using and developing the Python programming language.
   
-  ###  3- Linux Kernel Mentorship Programlink [Link](https://wiki.linuxfoundation.org/lkmp)
+  ###  (OCT) 3- Linux Kernel Mentorship Programlink [Link](https://wiki.linuxfoundation.org/lkmp)
 		Spring Program
    >- The  [Linux Kernel Mentorship Program](https://drive.google.com/file/d/1_P70rjCfiLq6PkqxTbhF0_y0bcA-Ryj-/view?usp=sharing "https://drive.google.com/file/d/1_P70rjCfiLq6PkqxTbhF0_y0bcA-Ryj-/view?usp=sharing")  offers a structured remote learning opportunity to aspiring Linux Kernel developers. Experienced Linux Kernel developers and maintainers mentor volunteer mentees and help them become contributors to the Linux Kernel.
   
-	###  4-Halite AI Bot Challenge [Link](https://halite.io/)
+	###  (OCT) 4-Halite AI Bot Challenge [Link](https://halite.io/)
 		Program Start
    >- ***Halite*** is an artificial intelligence challenge, created by Two Sigma. Participants write bots using the programming language of their choice to compete in an original online multiplayer game.
 
-	###  5-NJACK Winter of Code [Link]()
+	###  (OCT) 5-NJACK Winter of Code [Link]()
 		Program Announced
 	>- ***NJACK Winter of Code*** is an initiative by NJACK, IIT Patna, targeted at students who have never participated in Free or Open Source Software (FOSS) development before, as well as at those who have already become an expert in Open Source Development and are currently contributing to projects of any domain, say Web, Mobile, Machine Learning, Blockchain, IoT etc.
     
@@ -214,7 +214,7 @@ The Only requirement being an enthusiastic heart to learn.
 
 - ## :1st_place_medal: Hackathon
 
-    ### 1- I_Hack (IIT-B) [link](https://www.ecell.in/esummit/ihack/) 
+    ### (NOV) 1- I_Hack (IIT-B) [link](https://www.ecell.in/esummit/ihack/) 
 	    Registration Start 
     >-   At ***I_Hack***, we bring together India’s best coders, developers, designers, innovators, creators and entrepreneurs of tomorrow. I_Hack is geared up for those who are passionate about building, designing and innovating. It is a 30 Hr event where the enthusiasts meet, develop and compete in the product prototyping competition.
     >- I_Hack comprises of 3 parallel tracks : **BLOCKCHAIN TRACK**, **SOFTWARE TRACK**, **DATA TRACK**.
@@ -223,7 +223,7 @@ The Only requirement being an enthusiastic heart to learn.
 - ## :high_brightness: Open Source Event
 	
 	
-	### 1- GCI (Google Code In) [link](https://codein.withgoogle.com/about/) 
+	### (NOV) 1- GCI (Google Code In) [link](https://codein.withgoogle.com/about/) 
 		Application for Mentor Start
     >-   ***Google Code-in*** is a contest to introduce pre-university students (ages 13-17) to open source software development. 
     >-  *Mentor Responsibilities*: Help and/or teach the student how to be a part of your community, communicate more effectively and in the open, Keep track of their progress, keep student informed as to their status 
@@ -233,7 +233,7 @@ The Only requirement being an enthusiastic heart to learn.
 # <u> :earth_americas: `December` :flight_departure: </u>
 - ## :1st_place_medal: Hackathon
 
-    ### 1- SIH (Smart India Hackathon) [link](https://www.sih.gov.in)  [Linkdin](https://www.linkedin.com/company/smart-india-hackathon-2020/) 
+    ### (DEC) 1- SIH (Smart India Hackathon) [link](https://www.sih.gov.in)  [Linkdin](https://www.linkedin.com/company/smart-india-hackathon-2020/) 
 	    Registration Start
     >-   ***World’s Biggest Hackathon and Open Innovation model***, an initiative by Ministry of HRD 4th edition of highly successful.
     >-   Smart India Hackathon initiative Involves 2 Lakh+ students with 57,000+ ideas from 2200+ institutions against 530+ problem statements provided by 120+ organizations from across India.
@@ -241,15 +241,15 @@ The Only requirement being an enthusiastic heart to learn.
 
 - ## :high_brightness: Open Source Event
 
-    ### 1- KWoC (Kharagpur Winter of Code)  [link](https://kwoc.kossiitkgp.org)
+    ### (DEC) 1- KWoC (Kharagpur Winter of Code)  [link](https://kwoc.kossiitkgp.org)
 	    Application start
     >- ***Kharagpur Winter of Code*** is a 5-week long online programme for students who are new to open source software development. The programme not only helps students to get involved in open source, but also prepares them for many open source summer programmes; Google Summer of Code being one of them. The program is hosted by ***Kharagpur Open Source Society*** an independent student group at IIT Kharagpur, but is open to students of any university.
 
-    ### 2- KDE Student Programs.  [link](https://season.kde.org/)    
+    ### (DEC) 2- KDE Student Programs.  [link](https://season.kde.org/)    
     >- Focused on offering an opportunity to anyone (not just enrolled students) contributing to the KDE community, this is a program that is comparable to the well-known Google Summer of Code, with some special differences.
     >- A key difference is that [SoK](https://community.kde.org/SoK) projects are not limited to code-focused work, but any that benefit our community. For instance, projects can be about documentation, reports, translation, system administration, web and other types of work as well as code.
 
-	 ### 3- 24 Pull Requests [link](https://24pullrequests.com/about)    
+	 ### (DEC) 3- 24 Pull Requests [link](https://24pullrequests.com/about)    
     >- ***24 Pull Requests*** goal is to encourage contribution to open source projects during December. The site suggests open projects, highlights tickets that are good for new contributors, provides [guides for contributing](https://24pullrequests.com/contributing) and promotes good contributions submitted each day.
     >- The idea is simple: 'Send 24 pull requests between December 1st and December 24th', encouraging contributors to give back to open source projects with little gifts of code throughout December.
     


### PR DESCRIPTION
This is an easy and a simple replacement remedy for the issue of drop down menus of months, to navigate the repositories easily.
By this remedy, one can easily get to know the month corresponding to which the events have been showcased and would not need to scroll up all the way to the month headers to gain knowledge of the same.